### PR TITLE
7 scan email attachments for malicious content

### DIFF
--- a/Plugins/Extra/YaraScanner.py
+++ b/Plugins/Extra/YaraScanner.py
@@ -2,26 +2,37 @@ from Plugins import Plugin
 
 import Plugins.Config as Config
 
-import yara, requests, os
+import yara, requests, os, tkinter.filedialog, yaml
+
+
+from alive_progress import alive_bar
+from progress.bar import FillingSquaresBar as Bar
+from progress.spinner import Spinner
 
 class YaraScanner(Plugin.Plugin):
   def __init__(self, file_path: str = None, name: str = 'YaraScanner'):
     super().__init__(name)
     self._file_path = file_path
-    self._local_yara_cache_path = os.path.join(os.getenv("TMP"), ".yara_cache") # not used yet but could be useful later on to prevent consistent pulling of data.
+    self._local_yara_cache_path = os.path.join(os.getenv("TMP"), ".yara_cache")
+    self._local_temp_file_cache = os.path.join(os.getenv("TMP"), ".yara_download_cache")
+    self._github_token = os.getenv("GITHUB_TOKEN")
 
   def _getRuleLinks(self) -> dict:
     rules = Config.config['yara_sources']
     return rules
 
   # may have to convert this to a recursive rule in case of folders being within folders...
-  def _getGithubRules(self, owner, repo, path) -> list:
+  def _getGithubRuleLinks(self, owner, repo, path) -> list:
     if path == "__root__":
       url = f"https://api.github.com/repos/{owner}/{repo}/contents"
     else:
       url = f"https://api.github.com/repos/{owner}/{repo}/contents/{path}"
-    res = requests.get(url)
+    if self._github_token:
+      res = requests.get(url, headers={"Authorization": f"Bearer {self._github_token}"})
+    else:
+      res = requests.get(url)
     if res.status_code != 200:
+      print(f"Failed to query github: {res.content}")
       return None
     
     download_links = []
@@ -31,48 +42,113 @@ class YaraScanner(Plugin.Plugin):
       
     return download_links
 
-  def scanFile(self, filepath: str):
-    if filepath.endswith(".msg") or filepath.endswith(".eml"):
-      rule_sources = self._getRuleLinks()['email']
-    else:
-      rule_sources = self._getRuleLinks()['file']
-
-    rule_links = []
-    for source in rule_sources:
-      for path in source['paths']:
-        new_rules = self._getGithubRules(source['owner'], source['repo'], path)
-        if new_rules == None:
+  def _downloadRules(self, rule_links) -> list:
+    rules = []
+    with alive_bar(len(rule_links), title="Downloading rules", bar="smooth") as bar:
+      for rlink in rule_links:
+        rule = requests.get(rlink)
+        bar()
+        if rule.status_code != 200:
+          print(f'Failed to pull fule from: {rlink}')
           continue
-        rule_links = rule_links + self._getGithubRules(source['owner'], source['repo'], path)
+        with open(os.path.join(self._local_temp_file_cache, rlink.split('/')[-1]), "w+") as f:
+          f.write(rule.text)
+        rules.append((rlink, rule.text))
+    return rules
 
+  def _compileRules(self, rules) -> list:
+    if not os.path.exists(self._local_yara_cache_path):
+      os.mkdir(self._local_yara_cache_path)
+
+    compiled_rules_path_list = []
+    with alive_bar(len(rules), title="Compiling rules", bar="smooth") as bar:
+      for rule_link, rule in rules:
+        try:
+          compiled = yara.compile(source=rule)
+        except yara.SyntaxError as e:
+          print(f"Err: YARA Syntax error for rule \"{rule_link.split('/')[-1]}\": {e}")
+          continue
+        rule_path = os.path.join(self._local_yara_cache_path, rule_link.split('/')[-1])
+        compiled.save(rule_path)
+        compiled_rules_path_list.append(rule_path)
+        bar()
+    return compiled_rules_path_list
+  
+  def _getCompiledRules(self) -> list:
+    if not os.path.exists(self._local_yara_cache_path):
+      return None
+    
+    compiled_rules_path_list = []
+    dir_list = os.listdir(self._local_yara_cache_path)
+    with alive_bar(bar="smooth", title="Getting YARA rules") as spinner:
+      for item in dir_list:
+        if item.endswith(".yar"):
+          compiled_rules_path_list.append(os.path.join(self._local_yara_cache_path, item))
+        spinner()
+    return compiled_rules_path_list
+
+  def scanFile(self, filepath: str):
+    if not os.path.exists(self._local_yara_cache_path):
+      rule_sources = self._getRuleLinks()
+
+      rule_links = []
+      for source in rule_sources:
+        for path in source['paths']:
+          new_rules = self._getGithubRuleLinks(source['owner'], source['repo'], path)
+          if new_rules == None:
+            continue
+          rule_links = rule_links + self._getGithubRuleLinks(source['owner'], source['repo'], path)
+
+      if not os.path.exists(self._local_temp_file_cache):
+        os.mkdir(self._local_temp_file_cache)
+        rule_list = self._downloadRules(rule_links)
+        if not rule_list:
+          print("Failed to download rules. Exiting...")
+          exit(1)
+      else:
+        print("Using local download cache for compilation")
+        files = os.listdir(self._local_temp_file_cache)
+        rule_list = []
+        for file in files:
+          if file.endswith(".yar"):
+            rule_list.append(os.path.join(self._local_temp_file_cache, file))
+      print("Compiling and saving rules...")
+      compiled_rules = self._compileRules(rule_list)
+    else:
+      print(f"Getting compiled rules from {self._local_yara_cache_path}...")
+      compiled_rules = self._getCompiledRules()
 
     print(f"Performing YARA scan against: {filepath}")
-    for rule_link in rule_links:
-      rule = requests.get(rule_link)
-      if rule.status_code != 200:
-        print(f"Failed to pull rule from: {rule_link}")
-        continue
+    with alive_bar(len(compiled_rules), bar="smooth") as bar:
+      match_list = []
+      for compiled_rule in compiled_rules:
+        yara_scanner = yara.load(compiled_rule)
+        matches = yara_scanner.match(filepath)
+        if matches:
+          match_list.append(matches)
+        bar()
+    
+    print()
 
-      try:
-        compiled = yara.compile(source=rule.text) # precompiling the rules and placing them
-      except yara.SyntaxError as e:
-        print(f"Err: Yara Syntax error for rule \"{rule_link.split('/')[-1]}\": {e} ")
-        continue
-      matches = compiled.match(filepath)
-
-      if matches:
-        print("\nMatches found:")
+    if match_list:
+      print("detections:")
+      for matches in match_list:
         for match in matches:
-          print(f"- Rule name: {match.rule}")
-          print(f"  - Tags: {match.tags}")
+          print(f"  rule_{match.rule}:")
+          print(f"    tags:")
+          for tag in match.tags:
+            print(f"      - {tag}")
           for string in match.strings:
-            print("  - Strings:")
-            print(f"    - Identifier: {string.identifier}")
-            print(f"    - Instances: {string.instances}")
+            print("    strings:")
+            print(f"        {string.identifier}:")
+            for instance in string.instances:
+              print(f"          - {instance}")
           print()
+    else:
+      print("No matches found...")
 
   def run(self):
     if self._file_path == None:
-      self._file_path = input('Enter the full path for a file to scan: ').strip()
+      self._file_path = tkinter.filedialog.askopenfilename(initialdir="/", title="Select .msg file")
 
     self.scanFile(self._file_path)

--- a/Plugins/Extra/YaraScanner.py
+++ b/Plugins/Extra/YaraScanner.py
@@ -104,7 +104,7 @@ class YaraScanner(Plugin.Plugin):
         rule_list = self._downloadRules(rule_links)
         if not rule_list:
           print("Failed to download rules. Exiting...")
-          exit(1)
+          return
       else:
         print("Using local download cache for compilation")
         files = os.listdir(self._local_temp_file_cache)

--- a/config.json
+++ b/config.json
@@ -1,24 +1,20 @@
 {
   "version": "1.1.8",
-  "yara_sources": {
-    "email": [
-      {
-        "owner": "Yara-Rules",
-        "repo": "rules",
-        "paths": ["email"]
-      }
-    ],
-    "file": [
-      {
-        "owner": "Yara-Rules",
-        "repo": "rules",
-        "paths": ["malware", "webshells", "packers", "exploit_kits", "crypto", "antidebug_antivm", "maldocs", "capabilities"]
-      },
-      {
-        "owner": "j4ckd4n",
-        "repo": "yara",
-        "paths": ["__root__"]
-      }
-    ]
-  }
+  "yara_sources": [
+    {
+      "owner": "Yara-Rules",
+      "repo": "rules",
+      "paths": ["email"]
+    },
+    {
+      "owner": "Yara-Rules",
+      "repo": "rules",
+      "paths": ["malware", "webshells", "packers", "exploit_kits", "crypto", "antidebug_antivm", "maldocs", "capabilities"]
+    },
+    {
+      "owner": "j4ckd4n",
+      "repo": "yara",
+      "paths": ["__root__"]
+    }
+  ]
 }


### PR DESCRIPTION
## Description ##
YARA rules are now compiled and stored locally.

## Does this fix a known existing bug under Issues? ##
No

## Type of Change ##
Please delete any options that **do not** apply here:
- [ ] Bug Fix
- [X] New Feature
- [ ] Requires documentation additions / changes
- [ ] Other

## Any further info related to the addition ##
Initially, running YARA scans took a while due to the fact that they all had to be downloaded each and compiled every single time. This implementation checks to see if there are already cached `.yar` files within the `$ENV:TMP\\.yara*` directories and loads them in if there are. If the directories `.yara*` are missing, this will download it, compile and load them into memory. Consecutive scans will utilized cached compilations.
